### PR TITLE
Featured card setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,10 @@ gem 'image_processing', '~> 1.2'
 gem 'jbuilder', '~> 2.7'
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
+gem 'redis', '~> 4.0'
 gem 'sass-rails', '>= 6'
 gem 'turbolinks', '~> 5'
 gem 'webpacker', '~> 5.0'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -24,6 +23,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 5.0', '>= 5.0.1'
   gem 'shoulda-matchers'
   gem 'simplecov'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     diff-lcs (1.4.4)
     docile (1.3.5)
@@ -95,6 +97,7 @@ GEM
       thor (>= 0.14.0, < 2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
@@ -163,7 +166,9 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.2.5)
     regexp_parser (2.1.1)
+    rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -223,6 +228,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.12.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (5.3.0)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -251,6 +260,7 @@ DEPENDENCIES
   pry
   puma (~> 5.0)
   rails (~> 6.1.3, >= 6.1.3.2)
+  redis (~> 4.0)
   rspec-rails (~> 5.0, >= 5.0.1)
   sass-rails (>= 6)
   shoulda-matchers
@@ -259,6 +269,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 4.1.0)
+  webmock
   webpacker (~> 5.0)
 
 RUBY VERSION

--- a/NOTES.md
+++ b/NOTES.md
@@ -47,4 +47,12 @@ When a visitor visits the capitals index page:
 
 ### Issue 3
 
-- [ ] A card has a static map of the capital city
+- [x] A card has a static map of the capital city
+
+### Issue 4
+
+- [x] by default a random feature card displays upon page loading
+- [x] There is temporary card showing while the page loads
+- [x] Once loaded the featured card is the first card in the deck
+- [x] Clicking shuffle also updates the featured card
+- [x] Clicking directly on a card displays it as a featured card

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
   def index
     deck = Deck.create
-    deck.generate_deck(deck.id)
+    deck.generate_deck
     @cards = deck.cards
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ import * as ActiveStorage from '@rails/activestorage'
 import 'channels'
 import 'jquery'
 import 'packs/featuredCard'
+import 'packs/shuffle'
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,11 +3,12 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-import Rails from "@rails/ujs"
-import Turbolinks from "turbolinks"
-import * as ActiveStorage from "@rails/activestorage"
-import "channels"
-import "jquery"
+import Rails from '@rails/ujs'
+import Turbolinks from 'turbolinks'
+import * as ActiveStorage from '@rails/activestorage'
+import 'channels'
+import 'jquery'
+import 'packs/featuredCard'
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/featuredCard.js
+++ b/app/javascript/packs/featuredCard.js
@@ -1,17 +1,4 @@
-document.addEventListener("DOMContentLoaded", () => {
-
-const cardContainer = document.getElementById("cards")
-const button = document.getElementById("shuffle")
-                                                                  
-button.addEventListener("click", (event) => {
-  let cards = document.getElementsByClassName("card")
-                                                                  
-  let shuffled = _.shuffle(cards)
-  cardContainer.innerHTML = ""
-  shuffled.forEach(element => cardContainer.appendChild(element))
-  onLoad()
-})
-function onLoad() {
+export default function onLoad() {
   var featuredCard = document.getElementById('featuredCard')
   var cards = document.getElementById('cards').getElementsByTagName('div')
   featuredCard.replaceChildren(cards[0].cloneNode(true))
@@ -20,7 +7,3 @@ function onLoad() {
   mapImage.style.width = '600px'
 }
 window.addEventListener('load', onLoad)
-});
-
-
-

--- a/app/javascript/packs/featuredCard.js
+++ b/app/javascript/packs/featuredCard.js
@@ -1,3 +1,5 @@
+document.addEventListener("DOMContentLoaded", () => {
+
 const cardContainer = document.getElementById("cards")
 const button = document.getElementById("shuffle")
                                                                   
@@ -9,7 +11,6 @@ button.addEventListener("click", (event) => {
   shuffled.forEach(element => cardContainer.appendChild(element))
   onLoad()
 })
-
 function onLoad() {
   var featuredCard = document.getElementById('featuredCard')
   var cards = document.getElementById('cards').getElementsByTagName('div')
@@ -18,12 +19,8 @@ function onLoad() {
   mapImage.style.height = '600px'
   mapImage.style.width = '600px'
 }
-
-function onClick(card) {
-  document.getElementById('featuredCard').replaceChildren(card.cloneNode(true))
-  var mapImage = document.getElementById('featuredCard').getElementsByTagName('img')[0]
-  mapImage.style.height = '600px'
-  mapImage.style.width = '600px'
-}
-
 window.addEventListener('load', onLoad)
+});
+
+
+

--- a/app/javascript/packs/featuredCard.js
+++ b/app/javascript/packs/featuredCard.js
@@ -1,0 +1,29 @@
+const cardContainer = document.getElementById("cards")
+const button = document.getElementById("shuffle")
+                                                                  
+button.addEventListener("click", (event) => {
+  let cards = document.getElementsByClassName("card")
+                                                                  
+  let shuffled = _.shuffle(cards)
+  cardContainer.innerHTML = ""
+  shuffled.forEach(element => cardContainer.appendChild(element))
+  onLoad()
+})
+
+function onLoad() {
+  var featuredCard = document.getElementById('featuredCard')
+  var cards = document.getElementById('cards').getElementsByTagName('div')
+  featuredCard.replaceChildren(cards[0].cloneNode(true))
+  var mapImage = document.getElementById('featuredCard').getElementsByTagName('img')[0]
+  mapImage.style.height = '600px'
+  mapImage.style.width = '600px'
+}
+
+function onClick(card) {
+  document.getElementById('featuredCard').replaceChildren(card.cloneNode(true))
+  var mapImage = document.getElementById('featuredCard').getElementsByTagName('img')[0]
+  mapImage.style.height = '600px'
+  mapImage.style.width = '600px'
+}
+
+window.addEventListener('load', onLoad)

--- a/app/javascript/packs/shuffle.js
+++ b/app/javascript/packs/shuffle.js
@@ -1,0 +1,16 @@
+import onLoad from './featuredCard.js'
+
+document.addEventListener("DOMContentLoaded", () => {
+
+const cardContainer = document.getElementById("cards")
+const button = document.getElementById("shuffle")
+
+button.addEventListener("click", (event) => {
+  let cards = document.getElementsByClassName("card")
+
+  let shuffled = _.shuffle(cards)
+  cardContainer.innerHTML = ""
+  shuffled.forEach(element => cardContainer.appendChild(element))
+  onLoad()
+})
+});

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,4 +1,4 @@
 class Card < ApplicationRecord
   belongs_to :deck
-  validates :name, :country, :lat, :lon, :map_s, :map_l, :deck_id, presence: true
+  validates :name, :country, :lat, :lon, :map, :deck_id, presence: true
 end

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -3,17 +3,16 @@ require 'csv'
 class Deck < ApplicationRecord
   has_many :cards
 
-  def generate_deck(id)
+  def generate_deck
     data = CSV.read('lib/assets/data/capitals.csv')
     data.each do |row|
       map = MapService.get_map({ lat: row[2], lon: row[3] })
-      row != data[0] && Card.create!(
+      row != data[0] && cards.create!(
         name: row[1],
         country: row[0],
         lat: row[2].to_f,
         lon: row[3].to_f,
         map: map,
-        deck_id: id
       )
     end
   end

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -6,15 +6,13 @@ class Deck < ApplicationRecord
   def generate_deck(id)
     data = CSV.read('lib/assets/data/capitals.csv')
     data.each do |row|
-      map_s = MapService.get_small_map({ lat: row[2], lon: row[3] })
-      map_l = MapService.get_large_map({ lat: row[2], lon: row[3] })
+      map = MapService.get_map({ lat: row[2], lon: row[3] })
       row != data[0] && Card.create!(
         name: row[1],
         country: row[0],
         lat: row[2].to_f,
         lon: row[3].to_f,
-        map_s: map_s,
-        map_l: map_l,
+        map: map,
         deck_id: id
       )
     end

--- a/app/services/map_service.rb
+++ b/app/services/map_service.rb
@@ -1,11 +1,6 @@
 class MapService
-
-  def self.get_small_map(coordinates)
+  def self.get_map(coordinates)
     "https://www.mapquestapi.com/staticmap/v5/map?key=#{ENV["MAP_API_KEY"]}&locations=#{coordinates[:lat]},#{coordinates[:lon]}&defaultMarker=marker-sm-3B5998-22407F&size=200,200@2x&zoom=7"
-  end
-
-  def self.get_large_map(coordinates)
-    "https://www.mapquestapi.com/staticmap/v5/map?key=#{ENV["MAP_API_KEY"]}&locations=#{coordinates[:lat]},#{coordinates[:lon]}&defaultMarker=marker-sm-3B5998-22407F&size=300,300@2x&zoom=7"
   end
 end
 

--- a/app/services/map_service.rb
+++ b/app/services/map_service.rb
@@ -5,7 +5,7 @@ class MapService
   end
 
   def self.get_large_map(coordinates)
-    "https://www.mapquestapi.com/staticmap/v5/map?key=#{ENV["MAP_API_KEY"]}&locations=#{coordinates[:lat]},#{coordinates[:lon]}&defaultMarker=marker-sm-3B5998-22407F&size=400,400@2x&zoom=7"
+    "https://www.mapquestapi.com/staticmap/v5/map?key=#{ENV["MAP_API_KEY"]}&locations=#{coordinates[:lat]},#{coordinates[:lon]}&defaultMarker=marker-sm-3B5998-22407F&size=300,300@2x&zoom=7"
   end
 end
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,11 +1,12 @@
 <script src="https://code.jquery.com/jquery-3.5.0.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
+<% javascript_pack_tag 'featuredCard' %>
 
 <h1>Discover The Capital Cities Of The World</h1>
 
 <div id='featuredCard'>
         <figure>
-          <%= image_tag(@cards.shuffle.first.map_s) %>
+          <%= image_tag(@cards.shuffle.first.map_l) %>
           <figcaption>
             <h3><%= @cards.shuffle.first.name %></h3>
             <p>Capital Of: <%= @cards.shuffle.first.country %></p>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,6 +1,5 @@
 <script src="https://code.jquery.com/jquery-3.5.0.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
-<% javascript_pack_tag 'featuredCard' %>
 
 <h1>Discover The Capital Cities Of The World</h1>
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -6,7 +6,7 @@
 
 <div id='featuredCard'>
         <figure>
-          <%= image_tag(@cards.shuffle.first.map_l) %>
+          <%= image_tag(@cards.shuffle.first.map) %>
           <figcaption>
             <h3><%= @cards.shuffle.first.name %></h3>
             <p>Capital Of: <%= @cards.shuffle.first.country %></p>
@@ -21,7 +21,7 @@
   <% @cards.each do |card| %>
       <div class='card' id='card' onClick="onClick(this)">
         <figure>
-          <%= image_tag(card.map_s) %>
+          <%= image_tag(card.map) %>
           <figcaption>
             <h3><%= card.name %></h3>
             <p>Capital Of: <%= card.country %></p>
@@ -32,34 +32,11 @@
 </div>
 
 <script>
-  const cardContainer = document.getElementById("cards")
-  const button = document.getElementById("shuffle")
-                                                                    
-  button.addEventListener("click", (event) => {
-    let cards = document.getElementsByClassName("card")
-                                                                    
-    let shuffled = _.shuffle(cards)
-    cardContainer.innerHTML = ""
-    shuffled.forEach(element => cardContainer.appendChild(element))
-    onLoad()
-  })
-
-  function onLoad() {
-    var featuredCard = document.getElementById('featuredCard')
-    var cards = document.getElementById('cards').getElementsByTagName('div')
-    featuredCard.replaceChildren(cards[0].cloneNode(true))
-    var mapImage = document.getElementById('featuredCard').getElementsByTagName('img')[0]
-    mapImage.style.height = '600px'
-    mapImage.style.width = '600px'
-  }
-  
   function onClick(card) {
     document.getElementById('featuredCard').replaceChildren(card.cloneNode(true))
     var mapImage = document.getElementById('featuredCard').getElementsByTagName('img')[0]
     mapImage.style.height = '600px'
     mapImage.style.width = '600px'
   }
-  
-  window.addEventListener('load', onLoad)
 </script>
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,13 +3,24 @@
 
 <h1>Discover The Capital Cities Of The World</h1>
 
-<button type="button" id="shuffle">Shuffle</button>
+<div id='featuredCard'>
+        <figure>
+          <%= image_tag(@cards.shuffle.first.map_s) %>
+          <figcaption>
+            <h3><%= @cards.shuffle.first.name %></h3>
+            <p>Capital Of: <%= @cards.shuffle.first.country %></p>
+          </figcaption>
+        </figure>
+ </div>
+
+<button type='button' id='shuffle'>Shuffle</button>
 
 <div id='cards'>
+
   <% @cards.each do |card| %>
-      <div class='card'>
+      <div class='card' id='card' onClick="onClick(this)">
         <figure>
-          <%= image_tag(card.map_s, :size => '250x250') %>
+          <%= image_tag(card.map_s) %>
           <figcaption>
             <h3><%= card.name %></h3>
             <p>Capital Of: <%= card.country %></p>
@@ -29,6 +40,25 @@
     let shuffled = _.shuffle(cards)
     cardContainer.innerHTML = ""
     shuffled.forEach(element => cardContainer.appendChild(element))
+    onLoad()
   })
+
+  function onLoad() {
+    var featuredCard = document.getElementById('featuredCard')
+    var cards = document.getElementById('cards').getElementsByTagName('div')
+    featuredCard.replaceChildren(cards[0].cloneNode(true))
+    var mapImage = document.getElementById('featuredCard').getElementsByTagName('img')[0]
+    mapImage.style.height = '600px'
+    mapImage.style.width = '600px'
+  }
+  
+  function onClick(card) {
+    document.getElementById('featuredCard').replaceChildren(card.cloneNode(true))
+    var mapImage = document.getElementById('featuredCard').getElementsByTagName('img')[0]
+    mapImage.style.height = '600px'
+    mapImage.style.width = '600px'
+  }
+  
+  window.addEventListener('load', onLoad)
 </script>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :redis
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }

--- a/db/migrate/20210512000608_add_map_columns_to_cards.rb
+++ b/db/migrate/20210512000608_add_map_columns_to_cards.rb
@@ -1,6 +1,5 @@
 class AddMapColumnsToCards < ActiveRecord::Migration[6.1]
   def change
-    add_column :cards, :map_s, :text
-    add_column :cards, :map_l, :text
+    add_column :cards, :map, :text
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,8 +23,7 @@ ActiveRecord::Schema.define(version: 2021_05_12_000608) do
     t.bigint "deck_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "map_s"
-    t.text "map_l"
+    t.text "map"
     t.index ["deck_id"], name: "index_cards_on_deck_id"
   end
 

--- a/spec/features/pages/index_spec.rb
+++ b/spec/features/pages/index_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Index page features', type: :feature do
+  before :each do
+    stub_request(:get, 'www.example.com').to_return(body: 'abc')
+  end
+
   it 'Visiting the index page creates a deck of cards' do
     expect { visit root_path }.to change { Deck.count }.by(1)
   end

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Card, type: :model do
     it { should validate_presence_of :country }
     it { should validate_presence_of :lat }
     it { should validate_presence_of :lon }
-    it { should validate_presence_of :map_s }
-    it { should validate_presence_of :map_l }
+    it { should validate_presence_of :map }
   end
 
   describe 'Relationships' do

--- a/spec/models/deck_spec.rb
+++ b/spec/models/deck_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Deck, type: :model do
   describe 'Instance Methods' do
     it '#generate_deck' do
       deck = Deck.create
-      deck.generate_deck(deck.id)
+      deck.generate_deck
       expect(deck.cards.count).to_not eq(0)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,3 +68,12 @@ RSpec.configure do |config|
     end
   end
 end
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+  config.filter_sensitive_data('WEATHER_API_KEY') {ENV['WEATHER_API_KEY']}
+  config.filter_sensitive_data('MAP_API_KEY') {ENV['MAP_API_KEY']}
+  config.filter_sensitive_data('IMAGE_API_KEY') {ENV['IMAGE_API_KEY']}
+  config.default_cassette_options = { re_record_interval: 30.days }
+  config.configure_rspec_metadata!
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,12 +68,3 @@ RSpec.configure do |config|
     end
   end
 end
-VCR.configure do |config|
-  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
-  config.hook_into :webmock
-  config.filter_sensitive_data('WEATHER_API_KEY') {ENV['WEATHER_API_KEY']}
-  config.filter_sensitive_data('MAP_API_KEY') {ENV['MAP_API_KEY']}
-  config.filter_sensitive_data('IMAGE_API_KEY') {ENV['IMAGE_API_KEY']}
-  config.default_cassette_options = { re_record_interval: 30.days }
-  config.configure_rspec_metadata!
-end

--- a/spec/services/map_service_spec.rb
+++ b/spec/services/map_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe MapService do
   it 'Makes and API request to Mapquest' do
-    map = MapService.get_small_map({ lat: 39.738453, lon: -104.984853 })
+    map = MapService.get_map({ lat: 39.738453, lon: -104.984853 })
 
     expect(map).to be_a(String)
     expect(map).to include('https://www.mapquestapi.com/staticmap/v5/map?')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
+require 'webmock/rspec'
 require 'simplecov'
 SimpleCov.start 'rails'
 SimpleCov.start do


### PR DESCRIPTION
# Featured Card Setup

When the page loads a featured card loads first as the rest load. Once the list loads the first card get replaced but the first card on the list. 
Clicking shuffle shuffles the cards including the featured card which always reflects the first card
Clicking a card displays it as featured card.

## Summary

Added redis to cache
Removed a large map query because it was doubling the queries
Changed the Card table to reflect this change
Cleaned up deck generation
Abstracted most of the javascript out the view but not completely
