### PR TITLE
Generate deck once

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,9 @@
 class PagesController < ApplicationController
   def index
-    deck = Deck.create
-    deck.generate_countries_deck
+    deck = Deck.first || Deck.create
+    if deck.cards.none? 
+      deck.generate_countries_deck
+    end
     @cards = deck.cards
   end
 end

--- a/spec/features/pages/index_spec.rb
+++ b/spec/features/pages/index_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Index page features', type: :feature do
   it 'Cards include a Capital and its country and is listed in alphabetical order by country' do
     VCR.use_cassette('get_countries') do
       visit root_path
-      expect(page).to have_content('Explore The Countries Of The World')
+      expect(page).to have_content('Explore the Countries of the World')
 
       within(first('.card')) do
         expect(page).to have_content('Kabul')


### PR DESCRIPTION
# Fix duplicated tables

### Summary 
App was generating new decks every time the index page loaded.
That quickly exceeded the Heroku rows limit.
Fixed by changing index action to only generate a deck if one doesn't already exist.