### PR TITLE
Make time dynamic

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -31,9 +31,23 @@ class Card < ApplicationRecord
         count = 0
         self.images.attach(io: File.open(tempfile), filename: "#{self.name}-#{count += 1}")
       end
-    else
-      self.images
+     self.images
     end
+  end
+
+  def current_time(off_set)
+    arr = plus_or_minus(off_set)
+    n = extract_numbers(arr)
+    sec = n.map { |num| (num == n[0] && num * 60 * 60) || (num == n[1] && num * 60) }.sum
+    (Time.now.utc + sec).strftime('%A, %D -  %T')
+  end
+
+  def plus_or_minus(string)
+    string.include?('+') ? string.split(/[+:]/) : string.split(/[-:]/)
+  end
+
+  def extract_numbers(off_set_array)
+    off_set_array.map { |e| e.to_i if e != off_set_array[0] }.compact
   end
 end
 

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -15,7 +15,7 @@ class Deck < ApplicationRecord
         population: country_hash[:population],
         lat: country_hash[:latlng][0],
         lon: country_hash[:latlng][1],
-        timezones: current_time(country_hash[:timezones][0]),
+        timezones: country_hash[:timezones][0],
         alpha2Code: country_hash[:alpha2Code],
         currencies: country_hash[:currencies][0][:name],
         languages: languages(country_hash[:languages]),
@@ -27,21 +27,6 @@ class Deck < ApplicationRecord
   def languages(lang_arr)
     lang_string = lang_arr.map { |lang| lang[:name].capitalize }
     lang_string.join(', ')
-  end
-
-  def current_time(off_set)
-    arr = plus_or_minus(off_set)
-    n = extract_numbers(arr)
-    sec = n.map { |num| (num == n[0] && num * 60 * 60) || (num == n[1] && num * 60) }.sum
-    (Time.now.utc + sec).strftime('%A, %D -  %T')
-  end
-
-  def plus_or_minus(string)
-    string.include?('+') ? string.split(/[+:]/) : string.split(/[-:]/)
-  end
-
-  def extract_numbers(off_set_array)
-    off_set_array.map { |e| e.to_i if e != off_set_array[0] }.compact
   end
 end
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -19,7 +19,7 @@
         <ul>Population: <%= card.population %> </ul>
         <ul>Currency: <%= card.currencies %> </ul>
         <ul>Languages: <%= card.languages %></ul>
-        <ul>Date & Time: <%= card.timezones %> </ul>
+        <ul>Date & Time: <%= card.current_time(card.timezones) %> </ul>
         <div class='detailsLink'><%= link_to 'Details', card_path(card), method: :get %></div>
       </div>
     </div>


### PR DESCRIPTION
# Make the time in the card to update every time the page loads.

## Summary
The deck generates just one time, so the time in the card wasn't updating. To solve that the method current_time was moved from deck to card.
When a card uses the method current_time(off_set) returns the current time. 
Currently the method gets called every time the page refreshes. 
